### PR TITLE
Add real-world example to READMEPRIMERO

### DIFF
--- a/READMEPRIMERO.md
+++ b/READMEPRIMERO.md
@@ -1,0 +1,45 @@
+# Guía Inicial para Ofrecer Servicios con A2A
+
+Este repositorio contiene la especificación y recursos del **protocolo Agent2Agent (A2A)**. A2A permite que diferentes agentes de IA se comuniquen y colaboren de manera estandarizada, sin necesidad de compartir su lógica interna.
+
+## ¿Qué es A2A?
+- Un estándar abierto que utiliza JSON-RPC 2.0 sobre HTTP(S) para intercambiar mensajes entre agentes.
+- Soporta comunicación sincrónica, streaming mediante Server-Sent Events y notificaciones push para tareas de larga duración.
+- Cada agente publica una *Agent Card* (`/.well-known/agent.json`) donde declara sus habilidades, modalidades de interacción y requisitos de autenticación.
+
+## Servicios que puedes ofrecer
+1. **Integración de agentes**: conectar agentes existentes (por ejemplo, basados en LangGraph, CrewAI, Semantic Kernel) mediante A2A para orquestar flujos de trabajo complejos.
+2. **Desarrollo de agentes especializados**: crear agentes que expongan una API A2A y puedan ser utilizados por otros agentes o aplicaciones.
+3. **Consultoría y capacitación**: asesorar a equipos sobre buenas prácticas para implementar A2A y diseñar agentes seguros y escalables.
+4. **Extensión de herramientas**: añadir soporte A2A a sistemas propios o de terceros, facilitando la interoperabilidad.
+
+## Pasos para empezar
+1. Revisa la documentación principal en `docs/` y la [especificación](docs/specification.md).
+2. Instala la SDK de Python: `pip install a2a-sdk`.
+3. Consulta los [ejemplos](https://github.com/google-a2a/a2a-samples) para ver implementaciones de referencia.
+4. Crea tu propio agente siguiendo el tutorial en `docs/tutorials/python/`.
+
+Mantendremos este archivo como bitácora de lo aprendido y de las ideas para nuevos servicios.
+
+## Ejemplo práctico: consultor de empleados
+
+Para ponernos manos a la obra, te propongo un proyecto inicial muy ligado a la
+vida real. Imaginemos que una empresa quiere consultar una base de datos de
+empleados en lenguaje natural. El objetivo es que un agente pregunte al usuario
+por criterios como *"¿Deseas la información de los empleados españoles o
+franceses?"* y luego entregue un resumen con los datos solicitados.
+
+Pasos sugeridos:
+1. **Crear una base de datos** (por ejemplo en SQLite) con columnas como
+   `nombre`, `pais` y `cargo`.
+2. **Construir un agente** con la SDK de A2A que pueda recibir preguntas en
+   lenguaje natural, convertirlas en consultas a la base de datos y devolver la
+   respuesta.
+3. **Definir una Agent Card** en `/.well-known/agent.json` para documentar que
+   este agente acepta consultas de texto y responde con resúmenes de empleados.
+4. **Probar la interacción** localmente o mediante una API, animando al usuario
+   a experimentar con distintas preguntas.
+
+Con este pequeño proyecto podrás demostrar de inmediato cómo A2A facilita la
+creación de asistentes que trabajan con datos reales y responden de forma
+natural. ¡Sigamos explorando y ampliando estas ideas!


### PR DESCRIPTION
## Summary
- expand the Spanish READMEPRIMERO with a hands-on example for a database agent

## Testing
- `nox -s format` *(fails: no Python 3.11 interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb882fac8322a9de2ced83602e20