### PR TITLE
Remove binary DB and auto-create on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+samples/python/employee_agent/*.db

--- a/samples/python/employee_agent/.well-known/agent.json
+++ b/samples/python/employee_agent/.well-known/agent.json
@@ -1,0 +1,18 @@
+{
+  "name": "Employee Lookup Agent",
+  "description": "Returns employee info from a SQLite database",
+  "url": "http://localhost:9999/",
+  "version": "0.1.0",
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "capabilities": {"streaming": true},
+  "skills": [
+    {
+      "id": "employee_lookup",
+      "name": "Lookup employees",
+      "description": "Query employee records by country",
+      "tags": ["employees"],
+      "examples": ["Show employees from España"]
+    }
+  ]
+}

--- a/samples/python/employee_agent/README.md
+++ b/samples/python/employee_agent/README.md
@@ -1,0 +1,21 @@
+# Employee Lookup Agent
+
+This sample demonstrates a minimal A2A agent that queries a SQLite database of employees.
+The database file is not included in the repository and will be generated locally.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install a2a-sdk uvicorn
+   ```
+2. Create the database (optional, the server will create it on first run):
+   ```bash
+   python create_db.py
+   ```
+3. Start the server:
+   ```bash
+   python -m employee_agent
+   ```
+
+The agent exposes its capabilities in `.well-known/agent.json` and listens on port `9999`.

--- a/samples/python/employee_agent/__main__.py
+++ b/samples/python/employee_agent/__main__.py
@@ -1,0 +1,47 @@
+import uvicorn
+
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+
+from pathlib import Path
+
+from .agent_executor import EmployeeAgentExecutor
+from .create_db import DB_PATH, create_db
+
+
+if __name__ == "__main__":
+    skill = AgentSkill(
+        id="employee_lookup",
+        name="Lookup employees",
+        description="Query employee records by country",
+        tags=["employees"],
+        examples=["Show employees from España"],
+    )
+
+    agent_card = AgentCard(
+        name="Employee Lookup Agent",
+        description="Returns employee info from a SQLite database",
+        url="http://0.0.0.0:9999/",
+        version="0.1.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=AgentCapabilities(streaming=True),
+        skills=[skill],
+    )
+
+    db_path = DB_PATH
+    if not db_path.exists():
+        create_db()
+    request_handler = DefaultRequestHandler(
+        agent_executor=EmployeeAgentExecutor(str(db_path)),
+        task_store=InMemoryTaskStore(),
+    )
+
+    server = A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+    )
+
+    uvicorn.run(server.build(), host="0.0.0.0", port=9999)

--- a/samples/python/employee_agent/agent_executor.py
+++ b/samples/python/employee_agent/agent_executor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable, Tuple
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.utils import new_agent_text_message
+
+
+class EmployeeAgentExecutor(AgentExecutor):
+    """Agent that queries a SQLite database."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    def _query_db(self, country: str | None) -> Iterable[Tuple[str, str, str]]:
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        if country:
+            cur.execute(
+                "SELECT nombre, pais, cargo FROM employees WHERE pais = ?",
+                (country,),
+            )
+        else:
+            cur.execute("SELECT nombre, pais, cargo FROM employees")
+        results = cur.fetchall()
+        conn.close()
+        return results
+
+    def _extract_country(self, text: str) -> str | None:
+        lower = text.lower()
+        if "espa" in lower:
+            return "España"
+        if "fran" in lower:
+            return "Francia"
+        return None
+
+    async def execute(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        content = context.message.content or ""
+        country = self._extract_country(content)
+        rows = self._query_db(country)
+        if not rows:
+            result = "No results found."
+        else:
+            result = "\n".join(f"{n} - {c} ({p})" for n, c, p in rows)
+        await event_queue.enqueue_event(new_agent_text_message(result))
+
+    async def cancel(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        raise Exception("cancel not supported")

--- a/samples/python/employee_agent/create_db.py
+++ b/samples/python/employee_agent/create_db.py
@@ -1,0 +1,38 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).with_name("employees.db")
+
+EMPLOYEES = [
+    ("Ana", "España", "Ingeniera"),
+    ("Luis", "España", "Gerente"),
+    ("Marie", "Francia", "Analista"),
+    ("Pierre", "Francia", "Desarrollador"),
+]
+
+
+def create_db() -> None:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS employees (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            nombre TEXT,
+            pais TEXT,
+            cargo TEXT
+        )
+        """
+    )
+    cur.execute("SELECT COUNT(*) FROM employees")
+    count = cur.fetchone()[0]
+    if count == 0:
+        cur.executemany(
+            "INSERT INTO employees (nombre, pais, cargo) VALUES (?, ?, ?)", EMPLOYEES
+        )
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    create_db()


### PR DESCRIPTION
## Summary
- remove the `employees.db` binary from the repository
- ignore any future database files
- create the SQLite database at runtime if needed
- document that the database is generated locally

## Testing
- `python samples/python/employee_agent/create_db.py`
- `nox -s format -P 3.12`


------
https://chatgpt.com/codex/tasks/task_e_6849d18bd4408322be84f6f5471ca714